### PR TITLE
Fixed getting item trees

### DIFF
--- a/src/LeagueWrap/Dto/StaticData/ItemList.php
+++ b/src/LeagueWrap/Dto/StaticData/ItemList.php
@@ -35,12 +35,12 @@ class ItemList extends AbstractListDto
             $info['groups'] = $groups;
         }
         if (isset($info['tree'])) {
-            $tree = [];
+            $trees = [];
             foreach ($info['tree'] as $itemId => $tree) {
                 $itemTreeDto = new ItemTree($tree);
-                $tree[$itemId] = $itemTreeDto;
+                $trees[$itemId] = $itemTreeDto;
             }
-            $info['tree'] = $tree;
+            $info['tree'] = $trees;
         }
 
         parent::__construct($info);


### PR DESCRIPTION
The variable `$tree` was being used for the final array of trees, and each tree of the iteration at the same time, so the method was returning only the last tree.

This bug has existed since this file was first committed in April 2014 in the original repository.